### PR TITLE
[feat] 욕설 에러 받아오면 toast로 UI처리 - 에러 핸들링 변경

### DIFF
--- a/src/app/api/message/route.ts
+++ b/src/app/api/message/route.ts
@@ -28,7 +28,6 @@ export async function GET(req) {
 
 export async function POST(req) {
   const { username, content } = await req.json();
-
   try {
     const response = await axiosInstance.post(`/api/message`, {
       content,
@@ -40,8 +39,8 @@ export async function POST(req) {
     }
   } catch (err) {
     return NextResponse.json(
-      { error: 'Internal Server Error' },
-      { status: 500 },
+      { error: err.response.data.message },
+      { status: 451 },
     );
   }
 }

--- a/src/hooks/useCustomToast.tsx
+++ b/src/hooks/useCustomToast.tsx
@@ -49,9 +49,11 @@ const useCustomToast = () => {
   const promiseToast = (asyncfunc: () => Promise<void>) => {
     toast.promise(asyncfunc(), {
       success: { title: '처리완료되었습니다.', description: 'Looks great' },
-      error: {
-        title: '서버 에러가 났습니다.',
-        description: 'Something wrong',
+      error: (e: Error): { title: string; description: string } => {
+        return {
+          title: '경고',
+          description: e.message,
+        };
       },
       loading: { title: '서버에서 처리중입니다.', description: 'Please wait' },
     });

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -63,7 +63,11 @@ export const fetchPostCommnet = async (content: string, username: string) => {
       username,
     }),
   });
-  return response.status;
+  const data = await response.json();
+  if (response.status === 200) {
+    return data;
+  }
+  throw Error(data.error);
 };
 
 /* CALL Donate Money */


### PR DESCRIPTION
## ☑️ Describe your changes

- 작업 내용을 적어주세요
  > api변경 후 작업

POST api.peace-in-gaza.kr:8080/api/message 에서 
{
    "content":"ㅅㅂ",
    "username":"하이"
}

와 같이 욕설이 포함되어 있으면 반환값으로

statuscode: 451,
message: "욕설이 포함되어있습니다" 를 UI toast창에 적용시켰습니다!

util/api와 api/message를 변경했습니다!

## 📷 Screenshot

<img width="404" alt="image" src="https://github.com/project-GAZA/GazaFront/assets/51875363/8c9f2775-0485-48a3-94d6-35eb14bcade7">

## 🔗 Issue number and link

- closed #46 

