### PR TITLE
Feature #96 가자지구 사망자 상황 섹션 디자인 구현

### DIFF
--- a/.github/ISSUE_TEMPLATE/✅-feature.md
+++ b/.github/ISSUE_TEMPLATE/✅-feature.md
@@ -1,23 +1,15 @@
 ---
-name: "✅ FEATURE"
+name: '✅ FEATURE'
 about: Feature 작업 사항을 입력해주세요.
-title: "[Feat]"
-labels: ""
-assignees: ""
+title: '[Feature]'
+labels: ''
+assignees: ''
 ---
 
 ### Description
 
-> 설명을 작성해주세요.
-
 ### In Progress
 
-> 작업사항들을 작성해주세요.
-
-- [ ] todo1
-- [ ] todo2
-- [ ] todo3
+- [ ] 작업사항
 
 ### ETC
-
-> 기타사항

--- a/.github/ISSUE_TEMPLATE/🐛-bug.md
+++ b/.github/ISSUE_TEMPLATE/🐛-bug.md
@@ -1,23 +1,16 @@
 ---
 name: "\U0001F41B BUG"
 about: bug 발생 시 작성해주세요.
-title: "[BUG]"
-labels: ""
-assignees: ""
+title: '[BUG]'
+labels: ''
+assignees: ''
 ---
 
 ### Describe the bug
 
-> 버그에 대해 설명해주세요.
-
 ### To Reproduce
 
-> 버그 발생 과정을 기술하세요.
-
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+> 에러가 발생한 과정 기술
 
 ### Expected behavior
 
@@ -26,7 +19,3 @@ assignees: ""
 ### Screenshots
 
 > 화면 첨부파일
-
-### Additional context(Optional)
-
-> 발생한 문제에 대한 추가사항

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,11 +7,12 @@ import { deviceState } from '@/store/deviceState';
 
 import '@/style/globals.scss';
 
+import HeadMenu from '@/component/Common/Modules/HeadMenu';
 import SectionHero from '@/component/Section_Hero/Section';
 import SectionMessage from '@/component/Section_Message/Section';
 import SectionDonate from '@/component/Section_Donation/Section';
-import HeadMenu from '@/component/Common/Modules/HeadMenu';
 import SectionAdditional from '@/component/Section_Additional/Section';
+import SectionSituation from '@/component/Section_Situation/Section';
 
 import ModalController from './_components/ModalController';
 
@@ -41,7 +42,7 @@ const Home = () => {
       <Toaster />
       <HeadMenu infoRef={moreInfoRef} msgRef={messageRef} />
       <SectionHero msgRef={messageRef} />
-      <DeadInfoSection />
+      <SectionSituation />
       <WhoAmISection />
       <SectionMessage msgRef={messageRef} />
       <SectionDonate />

--- a/src/component/Section_Situation/Attom/InfoBox/index.module.scss
+++ b/src/component/Section_Situation/Attom/InfoBox/index.module.scss
@@ -1,0 +1,36 @@
+@import '@style/_mixin.scss';
+@import '@style/_variables.scss';
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
+  color: var(--white, var(--white, #fff));
+
+  width: 220px;
+  height: 160px;
+  @include respond-to('sm') {
+    width: 164px;
+  }
+}
+
+.number {
+  font-family: Georgia;
+  font-size: 40px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: normal;
+  @include respond-to('sm') {
+    font-size: 32px;
+  }
+}
+
+.title {
+  font-family: Inter;
+  font-size: 18px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+}

--- a/src/component/Section_Situation/Attom/InfoBox/index.stories.tsx
+++ b/src/component/Section_Situation/Attom/InfoBox/index.stories.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import InfoBox from './index';
+
+// 어떤 컴포넌트의 story인지, 어떤 설정으로 렌더링할지 정의
+export default {
+  title: 'stories/Section_Situation/Attoms/InfoBox',
+  component: InfoBox,
+  parameters: {
+    docs: {
+      description: { component: '메세지영역 제목' },
+    },
+  },
+  args: {
+    index: 10,
+    nick: 'JooKyungJin',
+    date: '2023.03.04',
+    isLike: true,
+    onClick: () => {
+      console.log('신고누름');
+    },
+    content: '뉴스를 봤는데 마음이 너무 아팠습니다.',
+    isdonate: true,
+  },
+} as ComponentMeta<typeof InfoBox>;
+
+// 기본 포맷을 정해두고 bind로 제어
+const Template: ComponentStory<typeof InfoBox> = args => <InfoBox {...args} />;
+
+// 각각이 새로운 스토리들
+// export const Small = () => <Button size="small" label="button" />; 얘와 같음
+
+export const Mobile: ComponentStory<typeof InfoBox> = Template.bind({});
+Mobile.parameters = {
+  viewport: {
+    defaultViewport: 'iphone12promax',
+  },
+};

--- a/src/component/Section_Situation/Attom/InfoBox/index.tsx
+++ b/src/component/Section_Situation/Attom/InfoBox/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from './index.module.scss';
+
+export interface InfoBoxType {
+  number: number;
+  title: string;
+  color?: 'white' | '#EB4511';
+}
+
+const InfoBox = ({ number, title, color = 'white' }: InfoBoxType) => {
+  return (
+    <div className={styles.layout}>
+      <h1 className={styles.number} style={{ color }}>
+        {number.toLocaleString()}
+      </h1>
+      <h3 className={styles.title}>{title}</h3>
+    </div>
+  );
+};
+
+export default InfoBox;

--- a/src/component/Section_Situation/Section/index.module.scss
+++ b/src/component/Section_Situation/Section/index.module.scss
@@ -1,0 +1,34 @@
+@import '@style/_variables.scss';
+@import '@style/_mixin.scss';
+
+.layout {
+  background: black;
+  display: inline-flex;
+  padding: 56px 236px 56px 228px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+}
+
+.title {
+  text-align: center;
+  color: var(--white, var(--white, #fff));
+  font-family: Inter;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+}
+
+.numberContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-content: center;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.innerContainer {
+}

--- a/src/component/Section_Situation/Section/index.module.scss
+++ b/src/component/Section_Situation/Section/index.module.scss
@@ -3,12 +3,7 @@
 
 .layout {
   background: black;
-  display: inline-flex;
-  padding: 56px 236px 56px 228px;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  gap: 20px;
+  padding: 56px 0 56px 0;
 }
 
 .title {
@@ -28,6 +23,17 @@
   align-content: center;
   gap: 32px;
   flex-wrap: wrap;
+  @include respond-to('sm') {
+    width: 360px;
+    margin: auto;
+  }
+  @include respond-to('md') {
+    width: 610px;
+    margin: auto;
+  }
+  @include respond-to('lg') {
+    width: 100%;
+  }
 }
 
 .innerContainer {

--- a/src/component/Section_Situation/Section/index.stories.tsx
+++ b/src/component/Section_Situation/Section/index.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import SectionMessage from './index';
+
+export default {
+  title: 'stories/Section_Message/Section',
+  component: SectionMessage,
+} as ComponentMeta<typeof SectionMessage>;
+
+const Template: ComponentStory<typeof SectionMessage> = args => (
+  <SectionMessage />
+);
+
+export const Mobile: ComponentStory<typeof SectionMessage> = Template.bind({});
+Mobile.parameters = {
+  viewport: {
+    defaultViewport: 'iphone14promax',
+  },
+};

--- a/src/component/Section_Situation/Section/index.tsx
+++ b/src/component/Section_Situation/Section/index.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import InfoBox, {
+  InfoBoxType,
+} from '@/component/Section_Situation/Attom/InfoBox';
+import styles from './index.module.scss';
+
+const SectionSituation = () => {
+  const [infos, setInfos] = useState<InfoBoxType[]>([]);
+  useEffect(() => {
+    setInfos([
+      { title: '사망자', number: 24620 },
+      { title: '부상자', number: 60800 },
+      { title: '어린이사망', number: 60800, color: '#EB4511' },
+      { title: '굶주린 사람들', number: 60800 },
+    ]);
+  }, []);
+  return (
+    <div className={styles.layout}>
+      <div className={styles.innerContainer}>
+        <h1 className={styles.title}>가자지구 최근 현황</h1>
+        <div className={styles.numberContainer}>
+          {infos.map(v => (
+            <InfoBox
+              title={v.title}
+              number={v.number}
+              key={v.title}
+              color={v.color}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SectionSituation;


### PR DESCRIPTION
## ☑️ Describe your changes

사망자 등 정보를 볼 수 있는 섹션 구현.
- 숫자+타이틀 박스 아톰 구현
- 반응형 디자인 적용

## 📷 Screenshot

### PC디자인
<img width="1181" alt="image" src="https://github.com/project-GAZA/GazaFront/assets/51875363/b4a50b02-4af3-40a7-acea-53c2f9a38286">

### 모바일
<img width="711" alt="image" src="https://github.com/project-GAZA/GazaFront/assets/51875363/6c8d4889-6e34-4173-8964-3d066759c2cc">

### Code

```tsx
export interface InfoBoxType {
  number: number;
  title: string;
  color?: 'white' | '#EB4511';
}

const InfoBox = ({ number, title, color = 'white' }: InfoBoxType) => {
  return (
    <div className={styles.layout}>
      <h1 className={styles.number} style={{ color }}>
        {number.toLocaleString()}
      </h1>
      <h3 className={styles.title}>{title}</h3>
    </div>
  );
};
```

컬러 정보가 'white'아니면 빨간색 색상 #EB4511 두 가지만 받는다.
숫자 정보는 자리수 ,표시 하는 함수 적용.


#### 반응형 디자인 미디어 쿼리

```scss
.numberContainer {
  display: flex;
  justify-content: center;
  align-items: center;
  align-content: center;
  gap: 32px;
  flex-wrap: wrap;
  @include respond-to('sm') {
    width: 360px;
    margin: auto;
  }
  @include respond-to('md') {
    width: 610px;
    margin: auto;
  }
  @include respond-to('lg') {
    width: 100%;
  }
}
```

flex로 넘기면 1개씩 넘어가서 고민한 결과 => 사이즈별로 width값을 줘서 모양 유지시킴.

## 추가 고려사항

현재 기획에는 4개의 숫자만 받는다. 따라서 4개에 맞는 디자인으로 구현했다.

확장성을 고려해서 아래줄에 2개씩 넘거가게 하는것도 고려를 해야할듯

## 🔗 Issue number and link

- 이슈 번호를 등록해주세요
  > closed #96 
